### PR TITLE
Create post and term parent classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "A bare theme for WordPress that uses TacoWordPress",
   "license": "proprietary",
   "minimum-stability": "dev",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "require": {
     "php": ">= 5.4"
   }

--- a/src/app/posts/Page.php
+++ b/src/app/posts/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-class Page extends \Taco\Post {
+class Page extends _Post {
 
   public $loaded_post = null;
 
@@ -60,6 +60,12 @@ class Page extends \Taco\Post {
 
     return $template_fields;
   }
+
+
+  public function isSortable() {
+    return true;
+  }
+
 
   /**
    * This should only be used on the admin side to manually load the post in getFields()

--- a/src/app/posts/Page.php
+++ b/src/app/posts/Page.php
@@ -31,6 +31,7 @@ class Page extends _Post {
     }
 
     return array_merge(
+      parent::getFields(),
       $this->getDefaultFields(),
       $fields_by_template
     );

--- a/src/app/posts/Post.php
+++ b/src/app/posts/Post.php
@@ -3,9 +3,9 @@
 class Post extends _Post {
 
   public function getFields() {
-    return array(
-      'created_for_testing' => array('type' => 'checkbox')
-    );
+    return array_merge(parent::getFields(), [
+      'created_for_testing' => array('type' => 'checkbox'),
+    ]);
   }
 
   public function getSingular() {

--- a/src/app/posts/Post.php
+++ b/src/app/posts/Post.php
@@ -1,6 +1,6 @@
 <?php
 
-class Post extends \Taco\Post {
+class Post extends _Post {
 
   public function getFields() {
     return array(

--- a/src/app/posts/Resource.php
+++ b/src/app/posts/Resource.php
@@ -2,8 +2,7 @@
 
 class Resource extends _Post {
   public function getFields() {
-
-    return array(
+    return array_merge(parent::getFields(), [
       'resource_authors'=>array(
         'type'=>'textarea',
         'description'=>'Separate author names with a semicolon and a space.',
@@ -28,7 +27,7 @@ class Resource extends _Post {
         'data-post-type'=>'Resource'
       ),
       'created_for_testing' => array('type' => 'checkbox')
-    );
+    ]);
   }
 
   public function getTaxonomies() {

--- a/src/app/posts/Resource.php
+++ b/src/app/posts/Resource.php
@@ -1,6 +1,6 @@
 <?php
 
-class Resource extends \Taco\Post {
+class Resource extends _Post {
   public function getFields() {
 
     return array(

--- a/src/app/posts/_Post.php
+++ b/src/app/posts/_Post.php
@@ -1,0 +1,46 @@
+<?php
+
+class _Post extends \Taco\Post {
+  
+  public static function isLoadable() {
+    return (static::class !== __CLASS__);
+  }
+  
+  
+  public function getFields() {
+    return [];
+  }
+  
+  
+  public function getHierarchical() {
+    return $this->isSortable();
+  }
+  
+  
+  public function isSortable() {
+    return false;
+  }
+  
+  
+  public function getPostTypeConfig() {
+    if(static::class === __CLASS__) return null;
+    
+    return parent::getPostTypeConfig();
+  }
+  
+  
+  /**
+   * Get all subclasses
+   * @return array
+   */
+  public static function getSubclasses() {
+    $subclasses = [];
+    foreach(get_declared_classes() as $class) {
+      if(is_subclass_of($class, static::class)) {
+        $subclasses[] = $class;
+      }
+    }
+    return $subclasses;
+  }
+  
+}

--- a/src/app/posts/_Post.php
+++ b/src/app/posts/_Post.php
@@ -4,11 +4,6 @@ class _Post extends \Taco\Post {
   use Pagination;
   
   
-  public static function isLoadable() {
-    return (static::class !== __CLASS__);
-  }
-  
-  
   public function getFields() {
     return [];
   }
@@ -24,8 +19,13 @@ class _Post extends \Taco\Post {
   }
   
   
+  public static function isLoadable() {
+    return (static::class !== self::class);
+  }
+  
+  
   public function getPostTypeConfig() {
-    if(static::class === __CLASS__) return null;
+    if(!self::isLoadable()) return null;
     
     return parent::getPostTypeConfig();
   }

--- a/src/app/posts/_Post.php
+++ b/src/app/posts/_Post.php
@@ -1,6 +1,8 @@
 <?php
 
 class _Post extends \Taco\Post {
+  use Pagination;
+  
   
   public static function isLoadable() {
     return (static::class !== __CLASS__);

--- a/src/app/posts/_Post.php
+++ b/src/app/posts/_Post.php
@@ -36,13 +36,9 @@ class _Post extends \Taco\Post {
    * @return array
    */
   public static function getSubclasses() {
-    $subclasses = [];
-    foreach(get_declared_classes() as $class) {
-      if(is_subclass_of($class, static::class)) {
-        $subclasses[] = $class;
-      }
-    }
-    return $subclasses;
+    return array_filter(get_declared_classes(), function($class){
+      return is_subclass_of($class, static::class);
+    });
   }
   
 }

--- a/src/app/taco-app.php
+++ b/src/app/taco-app.php
@@ -27,7 +27,10 @@ require_once __DIR__.'/traits/Taquito.php';
 require_once __DIR__.'/posts/AppOption.php';
 
 //posts
+require_once __DIR__.'/posts/_Post.php';
 require_once __DIR__.'/posts/Post.php';
 require_once __DIR__.'/posts/Page.php';
 
 //terms
+require_once __DIR__.'/terms/_Term.php';
+require_once __DIR__.'/terms/Category.php';

--- a/src/app/terms/Category.php
+++ b/src/app/terms/Category.php
@@ -3,7 +3,8 @@
 class Category extends _Term {
   
   public function getFields() {
-    return [];
+    return array_merge(parent::getFields(), [
+    ]);
   }
   
 }

--- a/src/app/terms/Category.php
+++ b/src/app/terms/Category.php
@@ -1,0 +1,9 @@
+<?php
+
+class Category extends _Term {
+  
+  public function getFields() {
+    return [];
+  }
+  
+}

--- a/src/app/terms/_Term.php
+++ b/src/app/terms/_Term.php
@@ -1,0 +1,14 @@
+<?php
+
+class _Term extends \Taco\Term {
+  
+  public function getFields() {
+    return [];
+  }
+  
+  
+  public static function isLoadable() {
+    return (static::class !== self::class);
+  }
+  
+}


### PR DESCRIPTION
This creates `_Post` and `_Term` classes, from which all other post and term classes should extend (except for `AppOption`). This provides a place for implementing traits and methods that are applicable to all post types and taxonomies.

Note: this *does not* account for namespacing, which will require additional modifications.